### PR TITLE
feat(dsl): short-circuit + None semantics (Issue #54)

### DIFF
--- a/nav_insights/core/dsl.py
+++ b/nav_insights/core/dsl.py
@@ -1,113 +1,410 @@
 from __future__ import annotations
 import ast
-from typing import Any, Dict
+import operator as op
+from typing import Any, Dict, Callable, Optional
+
+
+class ExpressionError(Exception):
+    """Base exception for DSL expression evaluation errors."""
+
+    pass
+
+
+class ParseError(ExpressionError):
+    """Exception raised for syntax errors in expressions."""
+
+    pass
+
+
+class UnsupportedNodeError(ExpressionError):
+    """Exception raised for unsupported AST nodes."""
+
+    pass
+
+
+class HelperNotFoundError(ExpressionError):
+    """Exception raised when a helper function is not found."""
+
+    pass
+
+
+class ResourceLimitError(ExpressionError):
+    """Exception raised when resource limits are exceeded."""
+
+    pass
 
 
 def value(path: str, root: Any, default=None) -> Any:
     """Safely access a dotted path on nested dicts/objects.
 
-    Returns `default` if any segment is missing or None."""
+    Returns `default` if any segment is missing or None.
+
+    Security: Only supports dict-like access and Pydantic models.
+    Does not allow arbitrary attribute access to minimize attack surface.
+
+    Graceful None behavior:
+    - If any segment in the path is None, returns `default`
+    - If the final value is None, returns `default`
+    - This prevents AttributeError/KeyError exceptions during path traversal
+    """
     cur = root
     for part in path.split("."):
         if cur is None:
             return default
         if isinstance(cur, dict):
             cur = cur.get(part)
+        elif hasattr(cur, "model_dump"):
+            # Pydantic model - convert to dict for safe access
+            try:
+                cur = cur.model_dump().get(part)
+            except Exception:
+                return default
+        elif hasattr(cur, "__getitem__") and hasattr(cur, "get"):
+            # Dict-like object with get method
+            try:
+                cur = cur.get(part)
+            except Exception:
+                return default
         else:
-            cur = getattr(cur, part, None)
+            # Unsupported object type - reject for security
+            return default
     return cur if cur is not None else default
 
 
+class DSLRegistry:
+    """Registry for DSL functions and accessors that can be extended by domain packs.
+
+    This allows domain-specific functionality to be registered without modifying core DSL code.
+    All registered functions must be safe and cannot access arbitrary system resources.
+    """
+
+    def __init__(self):
+        self._functions: Dict[str, Callable] = {
+            "min": min,
+            "max": max,
+        }
+        self._accessors: Dict[str, Callable] = {
+            "value": self._make_value_accessor,
+        }
+
+    def register_function(self, name: str, func: Callable) -> None:
+        """Register a safe function for use in DSL expressions.
+
+        Args:
+            name: Function name as it appears in expressions
+            func: Callable that implements the function
+
+        Raises:
+            ValueError: If name is already registered
+        """
+        if name in self._functions:
+            raise ValueError(f"Function '{name}' is already registered")
+        if not callable(func):
+            raise ValueError(f"Function '{name}' must be callable")
+        self._functions[name] = func
+
+    def register_accessor(self, name: str, func: Callable) -> None:
+        """Register a safe accessor function for use in DSL expressions.
+
+        Args:
+            name: Accessor name as it appears in expressions
+            func: Callable that creates the accessor given a root context
+
+        Raises:
+            ValueError: If name is already registered
+        """
+        if name in self._accessors:
+            raise ValueError(f"Accessor '{name}' is already registered")
+        if not callable(func):
+            raise ValueError(f"Accessor '{name}' must be callable")
+        self._accessors[name] = func
+
+    def get_function(self, name: str) -> Optional[Callable]:
+        """Get a registered function by name."""
+        return self._functions.get(name)
+
+    def get_accessor(self, name: str) -> Optional[Callable]:
+        """Get a registered accessor by name."""
+        return self._accessors.get(name)
+
+    def list_functions(self) -> Dict[str, Callable]:
+        """Return a copy of all registered functions."""
+        return self._functions.copy()
+
+    def list_accessors(self) -> Dict[str, Callable]:
+        """Return a copy of all registered accessors."""
+        return self._accessors.copy()
+
+    def clear(self) -> None:
+        """Clear all registered functions and accessors (except built-ins)."""
+        self._functions = {"min": min, "max": max}
+        self._accessors = {"value": self._make_value_accessor}
+
+    def _make_value_accessor(self, root: Any) -> Callable:
+        """Create a value accessor function bound to a root context."""
+
+        def value_fn(path: str, default=None):
+            return value(path, root, default)
+
+        return value_fn
+
+
+# Global registry instance
+_registry = DSLRegistry()
+
+
+def get_registry() -> DSLRegistry:
+    """Get the global DSL registry instance."""
+    return _registry
+
+
+def register_dsl_function(name: str, func: Callable) -> None:
+    """Convenience function to register a DSL function globally."""
+    _registry.register_function(name, func)
+
+
+def register_dsl_accessor(name: str, func: Callable) -> None:
+    """Convenience function to register a DSL accessor globally."""
+    _registry.register_accessor(name, func)
+
+
+# Legacy compatibility - maintaining the old ALLOWED_FUNCS for backward compatibility
 ALLOWED_FUNCS = {"min": min, "max": max}
 
 
+# Operator mapping for comparisons
+COMPARISON_OPS = {
+    ast.Eq: op.eq,
+    ast.NotEq: op.ne,
+    ast.Lt: op.lt,
+    ast.LtE: op.le,
+    ast.Gt: op.gt,
+    ast.GtE: op.ge,
+}
+
+# Arithmetic operator mapping
+ARITHMETIC_OPS = {
+    ast.Add: op.add,
+    ast.Sub: op.sub,
+    ast.Mult: op.mul,
+    ast.Div: op.truediv,
+    ast.Mod: op.mod,
+}
+
+# Unary operator mapping
+UNARY_OPS = {
+    ast.Not: op.not_,
+    ast.USub: op.neg,
+}
+
+
 class SafeEval(ast.NodeVisitor):
-    def __init__(self, ctx: Dict[str, Any]):
+    """Safe AST evaluator with resource limits and graceful None handling."""
+
+    def __init__(
+        self, ctx: Dict[str, Any], registry: Optional[DSLRegistry] = None, max_depth: int = 25
+    ):
         self.ctx = ctx
+        self.registry = registry or _registry
+        self.max_depth = max_depth
+        self.current_depth = 0
 
     def visit(self, node):
-        if isinstance(node, ast.Expression):
-            return self.visit(node.body)
-        elif isinstance(node, ast.Constant):
-            return node.value
-        elif isinstance(node, ast.Name):
-            if node.id in ("True", "False", "None"):
-                return {"True": True, "False": False, "None": None}[node.id]
-            raise ValueError(f"Name not allowed: {node.id}")
-        elif isinstance(node, ast.BinOp):
-            left = self.visit(node.left)
-            right = self.visit(node.right)
-            if isinstance(node.op, ast.Add):
-                return left + right
-            if isinstance(node.op, ast.Sub):
-                return left - right
-            if isinstance(node.op, ast.Mult):
-                return left * right
-            if isinstance(node.op, ast.Div):
-                return left / right
-            if isinstance(node.op, ast.Mod):
-                return left % right
-            raise ValueError("Operator not allowed")
-        elif isinstance(node, ast.BoolOp):
-            vals = [self.visit(v) for v in node.values]
-            if isinstance(node.op, ast.And):
-                out = True
-                for v in vals:
-                    out = out and v
-                return out
-            if isinstance(node.op, ast.Or):
-                out = False
-                for v in vals:
-                    out = out or v
-                return out
-            raise ValueError("Bool op not allowed")
-        elif isinstance(node, ast.UnaryOp):
-            v = self.visit(node.operand)
-            if isinstance(node.op, ast.Not):
-                return not v
-            if isinstance(node.op, ast.USub):
-                return -v
-            raise ValueError("Unary op not allowed")
-        elif isinstance(node, ast.Compare):
-            left = self.visit(node.left)
-            for op, comparator in zip(node.ops, node.comparators):
-                right = self.visit(comparator)
-                ok = (
-                    isinstance(op, ast.Eq)
-                    and (left == right)
-                    or isinstance(op, ast.NotEq)
-                    and (left != right)
-                    or isinstance(op, ast.Lt)
-                    and (left < right)
-                    or isinstance(op, ast.LtE)
-                    and (left <= right)
-                    or isinstance(op, ast.Gt)
-                    and (left > right)
-                    or isinstance(op, ast.GtE)
-                    and (left >= right)
-                )
-                if not ok:
+        # Check depth limit
+        self.current_depth += 1
+        if self.current_depth > self.max_depth:
+            raise ResourceLimitError(f"Expression AST depth exceeds limit of {self.max_depth}")
+
+        try:
+            if isinstance(node, ast.Expression):
+                return self.visit(node.body)
+            elif isinstance(node, ast.Constant):
+                return node.value
+            elif isinstance(node, ast.Name):
+                if node.id in ("True", "False", "None"):
+                    return {"True": True, "False": False, "None": None}[node.id]
+                raise UnsupportedNodeError(f"Name not allowed: {node.id}")
+            elif isinstance(node, ast.BinOp):
+                return self._handle_binop(node)
+            elif isinstance(node, ast.BoolOp):
+                return self._handle_boolop(node)
+            elif isinstance(node, ast.UnaryOp):
+                return self._handle_unaryop(node)
+            elif isinstance(node, ast.Compare):
+                return self._handle_compare(node)
+            elif isinstance(node, ast.Call):
+                return self._handle_call(node)
+            else:
+                raise UnsupportedNodeError(f"Node not allowed: {type(node).__name__}")
+        finally:
+            self.current_depth -= 1
+
+    def _handle_binop(self, node: ast.BinOp) -> Any:
+        """Handle binary operations with graceful None handling."""
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+
+        # Graceful None handling for arithmetic operations
+        if left is None or right is None:
+            return None
+
+        op_func = ARITHMETIC_OPS.get(type(node.op))
+        if not op_func:
+            raise UnsupportedNodeError(f"Binary operator not allowed: {type(node.op).__name__}")
+
+        try:
+            return op_func(left, right)
+        except (TypeError, ZeroDivisionError, ValueError) as e:
+            raise ExpressionError(f"Arithmetic error: {e}")
+
+    def _handle_boolop(self, node: ast.BoolOp) -> Any:
+        """Handle boolean operations with proper short-circuiting and None semantics.
+
+        Rules:
+        - AND: evaluate left-to-right; if any operand is falsy, return False (treat None as False).
+          If all operands are truthy, return True.
+        - OR: evaluate left-to-right; if any operand is truthy, return True.
+          If all operands are falsy (including None), return False.
+        """
+        if isinstance(node.op, ast.And):
+            for operand in node.values:
+                val = self.visit(operand)
+                if not bool(val):
                     return False
-                left = right
             return True
-        elif isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Name) and node.func.id == "value":
-                args = [self.visit(a) for a in node.args]
+        elif isinstance(node.op, ast.Or):
+            for operand in node.values:
+                val = self.visit(operand)
+                if bool(val):
+                    return True
+            return False
+        else:
+            raise UnsupportedNodeError(f"Boolean operator not allowed: {type(node.op).__name__}")
+
+    def _handle_unaryop(self, node: ast.UnaryOp) -> Any:
+        """Handle unary operations."""
+        operand = self.visit(node.operand)
+
+        op_func = UNARY_OPS.get(type(node.op))
+        if not op_func:
+            raise UnsupportedNodeError(f"Unary operator not allowed: {type(node.op).__name__}")
+
+        try:
+            return op_func(operand)
+        except (TypeError, ValueError) as e:
+            raise ExpressionError(f"Unary operation error: {e}")
+
+    def _handle_compare(self, node: ast.Compare) -> Any:
+        """Handle comparison operations with graceful None handling."""
+        left = self.visit(node.left)
+
+        for op_node, comparator in zip(node.ops, node.comparators):
+            right = self.visit(comparator)
+
+            # Special handling for None comparisons
+            if left is None and right is None:
+                # None == None is True, other comparisons with None are False
+                result = isinstance(op_node, ast.Eq)
+            elif left is None or right is None:
+                # One is None, other is not: only != is True
+                result = isinstance(op_node, ast.NotEq)
+            else:
+                # Normal comparison
+                op_func = COMPARISON_OPS.get(type(op_node))
+                if not op_func:
+                    raise UnsupportedNodeError(
+                        f"Comparison operator not allowed: {type(op_node).__name__}"
+                    )
+
+                try:
+                    result = op_func(left, right)
+                except (TypeError, ValueError) as e:
+                    raise ExpressionError(f"Comparison error: {e}")
+
+            if not result:
+                return False
+            left = right  # For chained comparisons
+        return True
+
+    def _handle_call(self, node: ast.Call) -> Any:
+        """Handle function calls."""
+        if not isinstance(node.func, ast.Name):
+            raise UnsupportedNodeError("Only simple function calls allowed")
+
+        func_name = node.func.id
+
+        # Try registered accessors first
+        accessor_factory = self.registry.get_accessor(func_name)
+        if accessor_factory:
+            args = [self.visit(a) for a in node.args]
+            # Special handling for value accessor
+            if func_name == "value":
                 if len(args) == 1 and isinstance(args[0], str):
                     return self.ctx["value"](args[0])
                 if len(args) == 2 and isinstance(args[0], str):
                     return self.ctx["value"](args[0], args[1])
-                raise ValueError("value() requires 'path' or ('path', default)")
-            elif isinstance(node.func, ast.Name) and node.func.id in ALLOWED_FUNCS:
-                f = ALLOWED_FUNCS[node.func.id]
-                args = [self.visit(a) for a in node.args]
-                return f(*args)
+                raise ExpressionError("value() requires 'path' or ('path', default)")
             else:
-                raise ValueError("Function not allowed")
-        else:
-            raise ValueError(f"Node not allowed: {type(node).__name__}")
+                # For other accessors, pass all args
+                accessor_func = accessor_factory(self.ctx.get("root"))
+                return accessor_func(*args)
+
+        # Try registered functions
+        func = self.registry.get_function(func_name)
+        if func:
+            args = [self.visit(a) for a in node.args]
+            try:
+                return func(*args)
+            except Exception as e:
+                raise ExpressionError(f"Function '{func_name}' error: {e}")
+
+        # Legacy compatibility - check ALLOWED_FUNCS
+        if func_name in ALLOWED_FUNCS:
+            f = ALLOWED_FUNCS[func_name]
+            args = [self.visit(a) for a in node.args]
+            try:
+                return f(*args)
+            except Exception as e:
+                raise ExpressionError(f"Built-in function '{func_name}' error: {e}")
+
+        raise HelperNotFoundError(f"Function '{func_name}' not found")
 
 
-def eval_expr(expr: str, root: Any) -> Any:
-    tree = ast.parse(expr, mode="eval")
-    return SafeEval({"value": lambda p, d=None: value(p, root, d)}).visit(tree)
+def eval_expr(
+    expr: str,
+    root: Any,
+    registry: Optional[DSLRegistry] = None,
+    max_length: int = 1024,
+    max_depth: int = 25,
+) -> Any:
+    """Evaluate a DSL expression safely against a root data structure.
+
+    Args:
+        expr: DSL expression string to evaluate
+        root: Root data structure to evaluate against
+        registry: Optional registry for custom functions/accessors
+        max_length: Maximum allowed expression length in characters
+        max_depth: Maximum allowed AST depth
+
+    Returns:
+        Result of expression evaluation
+
+    Raises:
+        ResourceLimitError: If expression exceeds length or depth limits
+        ParseError: If expression has invalid syntax
+        ExpressionError: If expression evaluation fails
+        UnsupportedNodeError: If expression contains disallowed operations
+        HelperNotFoundError: If a function is not found
+    """
+    # Check expression length limit
+    if len(expr) > max_length:
+        raise ResourceLimitError(f"Expression length {len(expr)} exceeds limit of {max_length}")
+
+    # Parse with proper error handling
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError as e:
+        raise ParseError(f"Expression syntax error: {e}")
+
+    ctx = {"value": lambda p, d=None: value(p, root, d), "root": root}
+    return SafeEval(ctx, registry, max_depth).visit(tree)

--- a/nav_insights/core/dsl_exceptions.py
+++ b/nav_insights/core/dsl_exceptions.py
@@ -1,22 +1,31 @@
 from __future__ import annotations
 
+
 class ExpressionError(Exception):
     """Base exception for DSL expression evaluation errors."""
+
     pass
+
 
 class ParseError(ExpressionError):
     """Exception raised for syntax errors in expressions."""
+
     pass
+
 
 class UnsupportedNodeError(ExpressionError):
     """Exception raised for unsupported AST nodes."""
+
     pass
+
 
 class HelperNotFoundError(ExpressionError):
     """Exception raised when a helper function is not found."""
+
     pass
+
 
 class ResourceLimitError(ExpressionError):
     """Exception raised when resource limits are exceeded."""
-    pass
 
+    pass

--- a/nav_insights/core/dsl_exceptions.py
+++ b/nav_insights/core/dsl_exceptions.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+class ExpressionError(Exception):
+    """Base exception for DSL expression evaluation errors."""
+    pass
+
+class ParseError(ExpressionError):
+    """Exception raised for syntax errors in expressions."""
+    pass
+
+class UnsupportedNodeError(ExpressionError):
+    """Exception raised for unsupported AST nodes."""
+    pass
+
+class HelperNotFoundError(ExpressionError):
+    """Exception raised when a helper function is not found."""
+    pass
+
+class ResourceLimitError(ExpressionError):
+    """Exception raised when resource limits are exceeded."""
+    pass
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,17 @@ service = [
     "uvicorn[standard]>=0.30",
 ]
 
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["nav_insights"]
+
 [tool.ruff]
 line-length = 100
 # Lowest common target across CI matrix

--- a/reviews/nav_insights/pr-55-dsl-testing-20250825_1607.md
+++ b/reviews/nav_insights/pr-55-dsl-testing-20250825_1607.md
@@ -1,0 +1,673 @@
+# 🔍 Claude Code Review: PR #55
+
+**Title:** feat(dsl): short-circuit + None semantics (Issue #54)  
+**Author:** datablogin  
+**Date:** 2025-08-25 16:07:02  
+**Branch:** feat/dsl-hardening-issue54 → main
+
+### PR Context
+- **Title:** feat(dsl): short-circuit + None semantics (Issue #54)
+- **Author:** datablogin
+- **Branch:** feat/dsl-hardening-issue54 → main
+- **Additions:** 446
+- **Deletions:** 80
+- **Files Changed:** 2
+- **Commits:** 2
+
+### Files in this PR:
+```
+nav_insights/core/dsl.py
+tests/test_dsl_issue54.py
+```
+
+### Code Changes:
+### ⚠️ Large Diff Summary (570 lines total, showing first 500 lines)
+
+```diff
+diff --git a/nav_insights/core/dsl.py b/nav_insights/core/dsl.py
+index 372e981..7291932 100644
+--- a/nav_insights/core/dsl.py
++++ b/nav_insights/core/dsl.py
+@@ -1,113 +1,410 @@
+ from __future__ import annotations
+ import ast
+-from typing import Any, Dict
++import operator as op
++from typing import Any, Dict, Callable, Optional
++
++
++class ExpressionError(Exception):
++    """Base exception for DSL expression evaluation errors."""
++
++    pass
++
++
++class ParseError(ExpressionError):
++    """Exception raised for syntax errors in expressions."""
++
++    pass
++
++
++class UnsupportedNodeError(ExpressionError):
++    """Exception raised for unsupported AST nodes."""
++
++    pass
++
++
++class HelperNotFoundError(ExpressionError):
++    """Exception raised when a helper function is not found."""
++
++    pass
++
++
++class ResourceLimitError(ExpressionError):
++    """Exception raised when resource limits are exceeded."""
++
++    pass
+ 
+ 
+ def value(path: str, root: Any, default=None) -> Any:
+     """Safely access a dotted path on nested dicts/objects.
+ 
+-    Returns `default` if any segment is missing or None."""
++    Returns `default` if any segment is missing or None.
++
++    Security: Only supports dict-like access and Pydantic models.
++    Does not allow arbitrary attribute access to minimize attack surface.
++
++    Graceful None behavior:
++    - If any segment in the path is None, returns `default`
++    - If the final value is None, returns `default`
++    - This prevents AttributeError/KeyError exceptions during path traversal
++    """
+     cur = root
+     for part in path.split("."):
+         if cur is None:
+             return default
+         if isinstance(cur, dict):
+             cur = cur.get(part)
++        elif hasattr(cur, "model_dump"):
++            # Pydantic model - convert to dict for safe access
++            try:
++                cur = cur.model_dump().get(part)
++            except Exception:
++                return default
++        elif hasattr(cur, "__getitem__") and hasattr(cur, "get"):
++            # Dict-like object with get method
++            try:
++                cur = cur.get(part)
++            except Exception:
++                return default
+         else:
+-            cur = getattr(cur, part, None)
++            # Unsupported object type - reject for security
++            return default
+     return cur if cur is not None else default
+ 
+ 
++class DSLRegistry:
++    """Registry for DSL functions and accessors that can be extended by domain packs.
++
++    This allows domain-specific functionality to be registered without modifying core DSL code.
++    All registered functions must be safe and cannot access arbitrary system resources.
++    """
++
++    def __init__(self):
++        self._functions: Dict[str, Callable] = {
++            "min": min,
++            "max": max,
++        }
++        self._accessors: Dict[str, Callable] = {
++            "value": self._make_value_accessor,
++        }
++
++    def register_function(self, name: str, func: Callable) -> None:
++        """Register a safe function for use in DSL expressions.
++
++        Args:
++            name: Function name as it appears in expressions
++            func: Callable that implements the function
++
++        Raises:
++            ValueError: If name is already registered
++        """
++        if name in self._functions:
++            raise ValueError(f"Function '{name}' is already registered")
++        if not callable(func):
++            raise ValueError(f"Function '{name}' must be callable")
++        self._functions[name] = func
++
++    def register_accessor(self, name: str, func: Callable) -> None:
++        """Register a safe accessor function for use in DSL expressions.
++
++        Args:
++            name: Accessor name as it appears in expressions
++            func: Callable that creates the accessor given a root context
++
++        Raises:
++            ValueError: If name is already registered
++        """
++        if name in self._accessors:
++            raise ValueError(f"Accessor '{name}' is already registered")
++        if not callable(func):
++            raise ValueError(f"Accessor '{name}' must be callable")
++        self._accessors[name] = func
++
++    def get_function(self, name: str) -> Optional[Callable]:
++        """Get a registered function by name."""
++        return self._functions.get(name)
++
++    def get_accessor(self, name: str) -> Optional[Callable]:
++        """Get a registered accessor by name."""
++        return self._accessors.get(name)
++
++    def list_functions(self) -> Dict[str, Callable]:
++        """Return a copy of all registered functions."""
++        return self._functions.copy()
++
++    def list_accessors(self) -> Dict[str, Callable]:
++        """Return a copy of all registered accessors."""
++        return self._accessors.copy()
++
++    def clear(self) -> None:
++        """Clear all registered functions and accessors (except built-ins)."""
++        self._functions = {"min": min, "max": max}
++        self._accessors = {"value": self._make_value_accessor}
++
++    def _make_value_accessor(self, root: Any) -> Callable:
++        """Create a value accessor function bound to a root context."""
++
++        def value_fn(path: str, default=None):
++            return value(path, root, default)
++
++        return value_fn
++
++
++# Global registry instance
++_registry = DSLRegistry()
++
++
++def get_registry() -> DSLRegistry:
++    """Get the global DSL registry instance."""
++    return _registry
++
++
++def register_dsl_function(name: str, func: Callable) -> None:
++    """Convenience function to register a DSL function globally."""
++    _registry.register_function(name, func)
++
++
++def register_dsl_accessor(name: str, func: Callable) -> None:
++    """Convenience function to register a DSL accessor globally."""
++    _registry.register_accessor(name, func)
++
++
++# Legacy compatibility - maintaining the old ALLOWED_FUNCS for backward compatibility
+ ALLOWED_FUNCS = {"min": min, "max": max}
+ 
+ 
++# Operator mapping for comparisons
++COMPARISON_OPS = {
++    ast.Eq: op.eq,
++    ast.NotEq: op.ne,
++    ast.Lt: op.lt,
++    ast.LtE: op.le,
++    ast.Gt: op.gt,
++    ast.GtE: op.ge,
++}
++
++# Arithmetic operator mapping
++ARITHMETIC_OPS = {
++    ast.Add: op.add,
++    ast.Sub: op.sub,
++    ast.Mult: op.mul,
++    ast.Div: op.truediv,
++    ast.Mod: op.mod,
++}
++
++# Unary operator mapping
++UNARY_OPS = {
++    ast.Not: op.not_,
++    ast.USub: op.neg,
++}
++
++
+ class SafeEval(ast.NodeVisitor):
+-    def __init__(self, ctx: Dict[str, Any]):
++    """Safe AST evaluator with resource limits and graceful None handling."""
++
++    def __init__(
++        self, ctx: Dict[str, Any], registry: Optional[DSLRegistry] = None, max_depth: int = 25
++    ):
+         self.ctx = ctx
++        self.registry = registry or _registry
++        self.max_depth = max_depth
++        self.current_depth = 0
+ 
+     def visit(self, node):
+-        if isinstance(node, ast.Expression):
+-            return self.visit(node.body)
+-        elif isinstance(node, ast.Constant):
+-            return node.value
+-        elif isinstance(node, ast.Name):
+-            if node.id in ("True", "False", "None"):
+-                return {"True": True, "False": False, "None": None}[node.id]
+-            raise ValueError(f"Name not allowed: {node.id}")
+-        elif isinstance(node, ast.BinOp):
+-            left = self.visit(node.left)
+-            right = self.visit(node.right)
+-            if isinstance(node.op, ast.Add):
+-                return left + right
+-            if isinstance(node.op, ast.Sub):
+-                return left - right
+-            if isinstance(node.op, ast.Mult):
+-                return left * right
+-            if isinstance(node.op, ast.Div):
+-                return left / right
+-            if isinstance(node.op, ast.Mod):
+-                return left % right
+-            raise ValueError("Operator not allowed")
+-        elif isinstance(node, ast.BoolOp):
+-            vals = [self.visit(v) for v in node.values]
+-            if isinstance(node.op, ast.And):
+-                out = True
+-                for v in vals:
+-                    out = out and v
+-                return out
+-            if isinstance(node.op, ast.Or):
+-                out = False
+-                for v in vals:
+-                    out = out or v
+-                return out
+-            raise ValueError("Bool op not allowed")
+-        elif isinstance(node, ast.UnaryOp):
+-            v = self.visit(node.operand)
+-            if isinstance(node.op, ast.Not):
+-                return not v
+-            if isinstance(node.op, ast.USub):
+-                return -v
+-            raise ValueError("Unary op not allowed")
+-        elif isinstance(node, ast.Compare):
+-            left = self.visit(node.left)
+-            for op, comparator in zip(node.ops, node.comparators):
+-                right = self.visit(comparator)
+-                ok = (
+-                    isinstance(op, ast.Eq)
+-                    and (left == right)
+-                    or isinstance(op, ast.NotEq)
+-                    and (left != right)
+-                    or isinstance(op, ast.Lt)
+-                    and (left < right)
+-                    or isinstance(op, ast.LtE)
+-                    and (left <= right)
+-                    or isinstance(op, ast.Gt)
+-                    and (left > right)
+-                    or isinstance(op, ast.GtE)
+-                    and (left >= right)
+-                )
+-                if not ok:
++        # Check depth limit
++        self.current_depth += 1
++        if self.current_depth > self.max_depth:
++            raise ResourceLimitError(f"Expression AST depth exceeds limit of {self.max_depth}")
++
++        try:
++            if isinstance(node, ast.Expression):
++                return self.visit(node.body)
++            elif isinstance(node, ast.Constant):
++                return node.value
++            elif isinstance(node, ast.Name):
++                if node.id in ("True", "False", "None"):
++                    return {"True": True, "False": False, "None": None}[node.id]
++                raise UnsupportedNodeError(f"Name not allowed: {node.id}")
++            elif isinstance(node, ast.BinOp):
++                return self._handle_binop(node)
++            elif isinstance(node, ast.BoolOp):
++                return self._handle_boolop(node)
++            elif isinstance(node, ast.UnaryOp):
++                return self._handle_unaryop(node)
++            elif isinstance(node, ast.Compare):
++                return self._handle_compare(node)
++            elif isinstance(node, ast.Call):
++                return self._handle_call(node)
++            else:
++                raise UnsupportedNodeError(f"Node not allowed: {type(node).__name__}")
++        finally:
++            self.current_depth -= 1
++
++    def _handle_binop(self, node: ast.BinOp) -> Any:
++        """Handle binary operations with graceful None handling."""
++        left = self.visit(node.left)
++        right = self.visit(node.right)
++
++        # Graceful None handling for arithmetic operations
++        if left is None or right is None:
++            return None
++
++        op_func = ARITHMETIC_OPS.get(type(node.op))
++        if not op_func:
++            raise UnsupportedNodeError(f"Binary operator not allowed: {type(node.op).__name__}")
++
++        try:
++            return op_func(left, right)
++        except (TypeError, ZeroDivisionError, ValueError) as e:
++            raise ExpressionError(f"Arithmetic error: {e}")
++
++    def _handle_boolop(self, node: ast.BoolOp) -> Any:
++        """Handle boolean operations with proper short-circuiting and None semantics.
++
++        Rules:
++        - AND: evaluate left-to-right; if any operand is falsy, return False (treat None as False).
++          If all operands are truthy, return True.
++        - OR: evaluate left-to-right; if any operand is truthy, return True.
++          If all operands are falsy (including None), return False.
++        """
++        if isinstance(node.op, ast.And):
++            for operand in node.values:
++                val = self.visit(operand)
++                if not bool(val):
+                     return False
+-                left = right
+             return True
+-        elif isinstance(node, ast.Call):
+-            if isinstance(node.func, ast.Name) and node.func.id == "value":
+-                args = [self.visit(a) for a in node.args]
++        elif isinstance(node.op, ast.Or):
++            for operand in node.values:
++                val = self.visit(operand)
++                if bool(val):
++                    return True
++            return False
++        else:
++            raise UnsupportedNodeError(f"Boolean operator not allowed: {type(node.op).__name__}")
++
++    def _handle_unaryop(self, node: ast.UnaryOp) -> Any:
++        """Handle unary operations."""
++        operand = self.visit(node.operand)
++
++        op_func = UNARY_OPS.get(type(node.op))
++        if not op_func:
++            raise UnsupportedNodeError(f"Unary operator not allowed: {type(node.op).__name__}")
++
++        try:
++            return op_func(operand)
++        except (TypeError, ValueError) as e:
++            raise ExpressionError(f"Unary operation error: {e}")
++
++    def _handle_compare(self, node: ast.Compare) -> Any:
++        """Handle comparison operations with graceful None handling."""
++        left = self.visit(node.left)
++
++        for op_node, comparator in zip(node.ops, node.comparators):
++            right = self.visit(comparator)
++
++            # Special handling for None comparisons
++            if left is None and right is None:
++                # None == None is True, other comparisons with None are False
++                result = isinstance(op_node, ast.Eq)
++            elif left is None or right is None:
++                # One is None, other is not: only != is True
++                result = isinstance(op_node, ast.NotEq)
++            else:
++                # Normal comparison
++                op_func = COMPARISON_OPS.get(type(op_node))
++                if not op_func:
++                    raise UnsupportedNodeError(
++                        f"Comparison operator not allowed: {type(op_node).__name__}"
++                    )
++
++                try:
++                    result = op_func(left, right)
++                except (TypeError, ValueError) as e:
++                    raise ExpressionError(f"Comparison error: {e}")
++
++            if not result:
++                return False
++            left = right  # For chained comparisons
++        return True
++
++    def _handle_call(self, node: ast.Call) -> Any:
++        """Handle function calls."""
++        if not isinstance(node.func, ast.Name):
++            raise UnsupportedNodeError("Only simple function calls allowed")
++
++        func_name = node.func.id
++
++        # Try registered accessors first
++        accessor_factory = self.registry.get_accessor(func_name)
++        if accessor_factory:
++            args = [self.visit(a) for a in node.args]
++            # Special handling for value accessor
++            if func_name == "value":
+                 if len(args) == 1 and isinstance(args[0], str):
+                     return self.ctx["value"](args[0])
+                 if len(args) == 2 and isinstance(args[0], str):
+                     return self.ctx["value"](args[0], args[1])
+-                raise ValueError("value() requires 'path' or ('path', default)")
+-            elif isinstance(node.func, ast.Name) and node.func.id in ALLOWED_FUNCS:
+-                f = ALLOWED_FUNCS[node.func.id]
+-                args = [self.visit(a) for a in node.args]
+-                return f(*args)
++                raise ExpressionError("value() requires 'path' or ('path', default)")
+             else:
+-                raise ValueError("Function not allowed")
+-        else:
+-            raise ValueError(f"Node not allowed: {type(node).__name__}")
++                # For other accessors, pass all args
++                accessor_func = accessor_factory(self.ctx.get("root"))
++                return accessor_func(*args)
++
++        # Try registered functions
++        func = self.registry.get_function(func_name)
++        if func:
++            args = [self.visit(a) for a in node.args]
++            try:
++                return func(*args)
++            except Exception as e:
++                raise ExpressionError(f"Function '{func_name}' error: {e}")
++
++        # Legacy compatibility - check ALLOWED_FUNCS
++        if func_name in ALLOWED_FUNCS:
++            f = ALLOWED_FUNCS[func_name]
++            args = [self.visit(a) for a in node.args]
++            try:
++                return f(*args)
++            except Exception as e:
++                raise ExpressionError(f"Built-in function '{func_name}' error: {e}")
++
++        raise HelperNotFoundError(f"Function '{func_name}' not found")
++
++
++def eval_expr(
++    expr: str,
++    root: Any,
++    registry: Optional[DSLRegistry] = None,
++    max_length: int = 1024,
++    max_depth: int = 25,
++) -> Any:
++    """Evaluate a DSL expression safely against a root data structure.
++
++    Args:
++        expr: DSL expression string to evaluate
++        root: Root data structure to evaluate against
++        registry: Optional registry for custom functions/accessors
++        max_length: Maximum allowed expression length in characters
++        max_depth: Maximum allowed AST depth
++
++    Returns:
++        Result of expression evaluation
++
++    Raises:
++        ResourceLimitError: If expression exceeds length or depth limits
++        ParseError: If expression has invalid syntax
++        ExpressionError: If expression evaluation fails
++        UnsupportedNodeError: If expression contains disallowed operations
++        HelperNotFoundError: If a function is not found
++    """
++    # Check expression length limit
++    if len(expr) > max_length:
++        raise ResourceLimitError(f"Expression length {len(expr)} exceeds limit of {max_length}")
+ 
++    # Parse with proper error handling
++    try:
++        tree = ast.parse(expr, mode="eval")
++    except SyntaxError as e:
++        raise ParseError(f"Expression syntax error: {e}")
+ 
+-def eval_expr(expr: str, root: Any) -> Any:
+-    tree = ast.parse(expr, mode="eval")
+-    return SafeEval({"value": lambda p, d=None: value(p, root, d)}).visit(tree)
++    ctx = {"value": lambda p, d=None: value(p, root, d), "root": root}
++    return SafeEval(ctx, registry, max_depth).visit(tree)
+diff --git a/tests/test_dsl_issue54.py b/tests/test_dsl_issue54.py
+new file mode 100644
+index 0000000..02a30c5
+--- /dev/null
++++ b/tests/test_dsl_issue54.py
+```
+Full diff: https://github.com/datablogin/nav-insights/pull/55/files
+\n---\n\n## Review Prompt Used\n\nPlease review this pull request for:
+- Code quality and correctness
+- Potential bugs
+- Performance considerations
+- Security concerns
+- Test coverage and determinism
+
+Be constructive and specific.
+
+For the DSL:
+- AST safety (no names/imports/attrs)
+- value(path, default) ergonomics and None-handling
+- Arithmetic/boolean correctness
+- Tests for tricky expressions
+
+Focus testing: unit coverage for rules/DSL, golden tests stability, fixtures quality.\n\n---\n\n## Claude Review Output\n
+# PR Review: DSL Hardening (Issue #54)
+
+## Overall Assessment: ⭐⭐⭐⭐⭐ Excellent
+
+This is a high-quality security hardening implementation that significantly improves the DSL's robustness while maintaining backward compatibility. The code demonstrates excellent security practices, comprehensive error handling, and thoughtful design patterns.
+
+## Code Quality & Correctness ✅
+
+**Strengths:**
+- **Security hardening**: Eliminated `getattr()` usage in `value()` function (`dsl.py:69`) - major security improvement from original
+- **Proper exception hierarchy**: Well-defined exception types (`ExpressionError`, `ParseError`, etc.)
+- **Short-circuit evaluation**: Correctly implemented for boolean operations (`dsl.py:269-280`)
+- **None semantics**: Graceful None handling across arithmetic, comparison, and boolean operations
+
+**Minor Issues:**
+- Line 409: Could cache `value` function creation to avoid lambda recreation
+- Registry implementation could benefit from thread-safety considerations for concurrent access
+
+## Security Analysis ✅ Excellent
+
+**Major Security Improvements:**
+- **AST node whitelisting**: Only allows safe operations (`dsl.py:219-238`)
+- **Eliminated arbitrary attribute access**: Removed dangerous `getattr()` usage
+- **Resource limits**: Expression length (1024 chars) and AST depth (25 levels) protection
+- **Function sandboxing**: Registry system prevents arbitrary function execution
+- **Pydantic model safety**: Uses `model_dump()` instead of direct attribute access (`dsl.py:56-61`)
+
+**Security Validation:**
+```python
+# These attacks are properly blocked:
+eval_expr("value.__class__", {})  # UnsupportedNodeError
+eval_expr("import os", {})        # ParseError  
+eval_expr("().__class__", {})     # UnsupportedNodeError
+```
+
+## Performance Considerations ⚠️ Good with Notes
+
+**Efficient Patterns:**
+- **Operator lookup tables**: `COMPARISON_OPS`, `ARITHMETIC_OPS` avoid repeated isinstance checks
+- **Short-circuit evaluation**: Prevents unnecessary computation in boolean ops
+- **Registry caching**: Functions/accessors retrieved once per evaluation
+
+**Performance Concerns:**
+1. **Depth tracking overhead**: `current_depth` incremented/decremented on every node visit
+2. **Exception wrapping**: Multiple try/catch blocks could impact hot paths
+3. **None propagation**: Additional type checks for arithmetic operations
+
+**Suggested optimizations:**
+```python
+# Could optimize depth tracking:
+if self.current_depth > self.max_depth:
+    raise ResourceLimitError(...)
+# vs checking in try/finally every time
+```
+
+## Test Coverage Analysis ✅ Good
+
+**Comprehensive Coverage:**
+- Short-circuit evaluation (`test_dsl_issue54.py:11-16`)
+- None semantics for arithmetic, comparison, logical ops
+- Resource limit enforcement
+- Security boundary testing
+
+**Test Quality:**
+- Deterministic test cases
+- Edge case coverage (None comparisons, deep nesting)
+- Error condition validation
+
+**Missing Tests:**
+- Concurrent access to registry
+- Performance regression tests
+- Memory usage under deep recursion
+- Chained comparison edge cases
+
+## AST Safety Validation ✅ Excellent
+
+**Whitelisted Nodes Only:**
+- `ast.Expression`, `ast.Constant`, `ast.Name` (limited), `ast.BinOp`, `ast.BoolOp`, `ast.UnaryOp`, `ast.Compare`, `ast.Call`
+- **Critical**: No `ast.Attribute`, `ast.Import`, `ast.Lambda` - properly secured
+
+**Safe Function Calls:**
+- Only `ast.Name` function calls allowed (no method calls)
+- Registry system provides controlled function access
+- Built-in functions properly sandboxed
+
+## Specific Issues Found
+
+### 🔴 Critical Issue: None Comparison Logic
+`dsl.py:304-310` - None comparison handling needs verification:
+```python
+if left is None and right is None:
+    result = isinstance(op_node, ast.Eq)  # Only == returns True
+elif left is None or right is None:
+    result = isinstance(op_node, ast.NotEq)  # Only != returns True
+```
+This logic is correct but could be clearer with explicit comments about Python None comparison semantics.
+
+### 🟡 Minor Issue: Registry Thread Safety
+The global registry (`_registry`) lacks thread-safety mechanisms. In a multi-tenant environment, concurrent registration could cause race conditions.
+
+### 🟡 Minor Issue: Error Message Consistency
+Error messages vary in format:
+- `dsl.py:226`: `"Name not allowed: {node.id}"`  
+- `dsl.py:370`: `"Function '{func_name}' not found"`
+
+Consider standardizing error message formatting.
+
+## Recommendations
+
+### Immediate:
+1. **Add thread locks** around registry modifications
+2. **Document None comparison behavior** more explicitly in docstrings
+3. **Add performance benchmarks** for resource limit testing
+
+### Future Enhancements:
+1. **Registry versioning** for backward compatibility
+2. **Expression compilation caching** for repeated evaluations
+3. **Metrics collection** for monitoring resource usage in production
+
+## Conclusion
+
+This PR represents excellent defensive programming and security hardening. The implementation successfully addresses Issue #54 with proper short-circuit evaluation and None semantics while significantly improving security posture. The code quality is production-ready with minimal concerns.
+
+**Recommendation: Approve and Merge** ✅
+
+The benefits of this hardening far outweigh the minor performance overhead, and the security improvements are essential for a rules engine handling potentially untrusted expressions.
+
+---
+**PR #55 Closes Issue #54**

--- a/tests/test_dsl_issue54.py
+++ b/tests/test_dsl_issue54.py
@@ -3,8 +3,15 @@
 Extended with short-circuit and None-semantics tests (Issue #54).
 """
 
+import importlib
+
 import pytest
+
+import nav_insights.core.dsl as dsl_mod
 from nav_insights.core.dsl import eval_expr
+
+# Ensure we reload DSL module from this worktree to avoid stale imports in combined test runs
+importlib.reload(dsl_mod)
 
 
 class TestShortCircuitAndNoneSemantics:
@@ -66,4 +73,3 @@ class TestResourceLimitsAndErrors:
     def test_builtin_funcs_ok(self):
         assert eval_expr("min(10, 5, 20)", {}) == 5
         assert eval_expr("max(10, 5, 20)", {}) == 20
-

--- a/tests/test_dsl_issue54.py
+++ b/tests/test_dsl_issue54.py
@@ -1,0 +1,38 @@
+"""Comprehensive tests for the DSL expression evaluator and registry system.
+
+Extended with short-circuit and None-semantics tests (Issue #54).
+"""
+
+import pytest
+from nav_insights.core.dsl import eval_expr
+
+
+class TestShortCircuitAndNoneSemantics:
+    def test_short_circuit_and(self):
+        # Right side raises if evaluated; must short-circuit
+        assert eval_expr("False and (1/0)", {}) is False
+
+    def test_short_circuit_or(self):
+        assert eval_expr("True or (1/0)", {}) is True
+
+    def test_none_arithmetic_rules(self):
+        # Arithmetic with None => None
+        assert eval_expr("None + 1", {}) is None
+        assert eval_expr("1 + None", {}) is None
+        assert eval_expr("None * 5", {}) is None
+
+    def test_none_comparison_rules(self):
+        # Comparisons with None => False except equality to None
+        assert eval_expr("None == None", {}) is True
+        assert eval_expr("None != None", {}) is False
+        assert eval_expr("None < 1", {}) is False
+        assert eval_expr("None > 1", {}) is False
+        assert eval_expr("1 == None", {}) is False
+        assert eval_expr("1 != None", {}) is True
+
+    def test_none_logical_rules(self):
+        # Logical ops: None treated as False
+        assert eval_expr("None and True", {}) is False
+        assert eval_expr("None or True", {}) is True
+        assert eval_expr("not None", {}) is True
+


### PR DESCRIPTION
## Description
Implements hardened DSL semantics per Issue #54.
- Short-circuit logical evaluation (and/or) with left-to-right order
- None semantics:
  - Arithmetic with None => None
  - Comparisons with None => False (except None == None is True)
  - Logical ops treat None as False
- Resource limits: expression length and AST depth checks
- Tests added in tests/test_dsl_issue54.py

Fixes #54

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Docs update only

## How Has This Been Tested?
- Added unit tests in tests/test_dsl_issue54.py covering short-circuit, None semantics, resource limits, and error conditions
- Ran pytest locally across the new tests

## Checklist:
- [x] Code follows project style guidelines (ruff)
- [x] Self-review completed
- [x] Added code comments where helpful
- [x] Updated/added tests
- [x] Local tests passing (new tests)
- [x] No new warnings introduced
