### PR TITLE
feat(paid-search): implement VideoCreative analyzer → IR mapping (#46)

### DIFF
--- a/docs/mappings/paid_search/video_creative_to_ir.md
+++ b/docs/mappings/paid_search/video_creative_to_ir.md
@@ -1,0 +1,132 @@
+# Mapping Spec: PaidSearch VideoCreative → Core IR (AuditFindings)
+
+Status: Draft
+Owner: paid_search domain
+
+## Summary
+Map outputs from PaidSearchNav VideoCreative analyzer to Core IR AuditFindings using Pydantic base types. Handles video creative performance analysis including creative asset performance, audience insights, and view-through metrics.
+
+## Source examples
+- Example customer: /Users/robertwelborn/PycharmProjects/PaidSearchNav/customers/example_customer/video_creative_20250824_180711.json
+- Test fixtures: tests/fixtures/video_creative_happy_path.json, tests/fixtures/video_creative_edge_case.json
+
+## Input shape (observed)
+- analyzer: "VideoCreative" 
+- customer_id: str (e.g., Google Ads account)
+- analysis_period: { start_date: ISO datetime, end_date: ISO datetime }
+- timestamp: ISO datetime
+- summary: {
+  total_video_creatives: int,
+  poor_performers_count: int,
+  top_performers_count: int,
+  total_video_spend_micros: int,
+  average_view_rate: float [0..1],
+  priority_level: "LOW"|"MEDIUM"|"HIGH"|"CRITICAL"
+}
+- detailed_findings:
+  - poor_performers: [ { 
+    creative_id: str, 
+    creative_name: str, 
+    video_duration_seconds: int,
+    impressions: int,
+    views: int, 
+    view_rate: float [0..1],
+    cost_micros: int,
+    conversions: int,
+    cpa_micros: int|null,
+    campaign: str,
+    ad_group: str,
+    recommendation: str,
+    performance_score: float [0..1]
+  } ]
+  - top_performers: [ { 
+    creative_id: str,
+    creative_name: str,
+    video_duration_seconds: int,
+    impressions: int,
+    views: int,
+    view_rate: float [0..1], 
+    cost_micros: int,
+    conversions: int,
+    cpa_micros: int|null,
+    campaign: str,
+    ad_group: str,
+    recommendation: str,
+    performance_score: float [0..1]
+  } ]
+  - insights: [str]
+  - recommendations: [str]
+
+## IR target
+- AuditFindings
+  - account: AccountMeta(account_id = customer_id)
+  - date_range: DateRange(start_date = date(analysis_period.start_date), end_date = date(analysis_period.end_date))
+  - totals: Totals with video spend converted from micros to USD
+  - aggregates: store high-level summary metrics under aggregates.video = {...}
+  - findings: one Finding per poor_performers[] item and per top_performers[] item
+  - data_sources: Evidence entry referencing the analyzer
+  - analyzers: AnalyzerProvenance(name="VideoCreative", version=?, git_sha=?, started_at=?, finished_at=timestamp)
+
+## Finding mapping
+- category: creative
+- severity: map summary.priority_level → Severity
+  - CRITICAL→high; HIGH→high; MEDIUM→medium; LOW→low
+- summary: "Poor video creative: {creative_name}" or "Top video creative: {creative_name}"
+- description: source recommendation text
+- entities: include creative as EntityRef(type="other", id=creative:{creative_id}, name=creative_name); include campaign and ad_group EntityRefs
+- dims: store video_duration_seconds, campaign, ad_group, performance_score
+- metrics (Decimal-compatible numerics): impressions, views, view_rate, cost_usd (converted from micros), conversions, cpa_usd (converted from micros, omit if null)
+- evidence: Evidence(source="paid_search_nav.video_creative", entities=[creative_entity])
+
+## Unit conversions
+- cost_micros → cost_usd: divide by 1,000,000
+- cpa_micros → cpa_usd: divide by 1,000,000, omit if null/N/A
+- total_video_spend_micros → spend_usd: divide by 1,000,000
+
+## Example IR finding (poor performer)
+```json
+{
+  "category": "creative",
+  "summary": "Poor video creative: Summer Sale 30s",
+  "description": "Low view rate (12%) - consider shorter duration or more engaging opening",
+  "severity": "high",
+  "entities": [
+    {"type": "other", "id": "creative:12345", "name": "Summer Sale 30s"},
+    {"type": "campaign", "id": "cmp:Video Campaign", "name": "Video Campaign"},
+    {"type": "ad_group", "id": "adg:Video Ad Group", "name": "Video Ad Group"}
+  ],
+  "dims": {
+    "video_duration_seconds": 30,
+    "campaign": "Video Campaign",
+    "ad_group": "Video Ad Group",
+    "performance_score": 0.12
+  },
+  "metrics": {
+    "impressions": 45000,
+    "views": 5400,
+    "view_rate": 0.12,
+    "cost_usd": 892.45,
+    "conversions": 0,
+    "performance_score": 0.12
+  },
+  "evidence": [
+    {"source": "paid_search_nav.video_creative", "entities": []}
+  ]
+}
+```
+
+## Acceptance criteria
+- Parse sample inputs into AuditFindings with ≥1 finding per poor_performer and per top_performer
+- All required core fields validate via Pydantic; schema_version="1.0.0"
+- Severity mapping documented and applied
+- Currency values converted from micros to USD as Decimal numbers
+- Unit tests covering:
+  - happy-path mapping for poor and top performers
+  - missing optional fields (cpa_micros handling)
+  - enum fallbacks
+  - micro-to-USD conversions
+
+## Open questions / notes
+- Video creative entities may benefit from a dedicated EntityType.creative in the future
+- Performance scores and view rates provide rich creative optimization insights
+- Consider adding video-specific aggregates for view-through metrics

--- a/nav_insights/integrations/paid_search/__init__.py
+++ b/nav_insights/integrations/paid_search/__init__.py
@@ -1,1 +1,4 @@
 # Paid Search integrations
+from .video_creative import parse_video_creative
+
+__all__ = ["parse_video_creative"]

--- a/nav_insights/integrations/paid_search/video_creative.py
+++ b/nav_insights/integrations/paid_search/video_creative.py
@@ -33,7 +33,7 @@ class VideoCreativeInput(BaseModel):
 def _validate_numeric_ranges(item: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and clamp numeric values to expected ranges."""
     validated_item = item.copy()
-    
+
     # Validate view_rate is in [0,1] range
     if "view_rate" in validated_item:
         try:
@@ -43,8 +43,8 @@ def _validate_numeric_ranges(item: Dict[str, Any]) -> Dict[str, Any]:
                 validated_item["view_rate"] = max(0, min(1, view_rate))
         except (ValueError, TypeError):
             validated_item["view_rate"] = 0
-    
-    # Validate performance_score is in [0,1] range  
+
+    # Validate performance_score is in [0,1] range
     if "performance_score" in validated_item:
         try:
             perf_score = float(validated_item["performance_score"])
@@ -52,7 +52,7 @@ def _validate_numeric_ranges(item: Dict[str, Any]) -> Dict[str, Any]:
                 validated_item["performance_score"] = max(0, min(1, perf_score))
         except (ValueError, TypeError):
             validated_item["performance_score"] = 0
-    
+
     return validated_item
 
 
@@ -60,10 +60,10 @@ def _extract_creative_info(item: Dict[str, Any]) -> Tuple[str, str]:
     """Extract and validate creative ID and name from item."""
     creative_id = str(item.get("creative_id", "unknown"))
     creative_name = str(item.get("creative_name", "Unknown Creative"))
-    
+
     if not creative_name.strip():
         creative_name = "Unknown Creative"
-    
+
     return creative_id, creative_name
 
 
@@ -71,41 +71,35 @@ def _build_entities(creative_id: str, creative_name: str, item: Dict[str, Any]) 
     """Build EntityRef objects for creative, campaign, and ad group."""
     # Create creative entity
     creative_entity = EntityRef(
-        type=EntityType.other,
-        id=f"creative:{creative_id}",
-        name=creative_name
+        type=EntityType.other, id=f"creative:{creative_id}", name=creative_name
     )
-    
+
     entities = [creative_entity]
-    
+
     # Handle campaign and ad group entities
     campaign_value = item.get("campaign")
     ad_group_value = item.get("ad_group")
-    
+
     campaign_name = str(campaign_value) if campaign_value is not None else ""
     ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
-    
+
     if campaign_name and campaign_name.strip():
-        entities.append(EntityRef(
-            type=EntityType.campaign,
-            id=f"cmp:{campaign_name}",
-            name=campaign_name
-        ))
-        
+        entities.append(
+            EntityRef(type=EntityType.campaign, id=f"cmp:{campaign_name}", name=campaign_name)
+        )
+
     if ad_group_name and ad_group_name.strip():
-        entities.append(EntityRef(
-            type=EntityType.ad_group,
-            id=f"adg:{ad_group_name}",
-            name=ad_group_name
-        ))
-    
+        entities.append(
+            EntityRef(type=EntityType.ad_group, id=f"adg:{ad_group_name}", name=ad_group_name)
+        )
+
     return entities
 
 
 def _build_metrics(item: Dict[str, Any]) -> Dict[str, Decimal]:
     """Build metrics dictionary with micro-to-USD conversions and validation."""
     metrics = {}
-    
+
     # Standard metrics
     metric_fields = ["impressions", "views", "conversions", "performance_score"]
     for field in metric_fields:
@@ -114,7 +108,7 @@ def _build_metrics(item: Dict[str, Any]) -> Dict[str, Decimal]:
                 metrics[field] = Decimal(str(item[field]))
             except (ValueError, TypeError):
                 metrics[field] = Decimal("0")
-    
+
     # View rate with validation
     if "view_rate" in item:
         try:
@@ -125,7 +119,7 @@ def _build_metrics(item: Dict[str, Any]) -> Dict[str, Decimal]:
             metrics["view_rate"] = view_rate
         except (ValueError, TypeError):
             metrics["view_rate"] = Decimal("0")
-    
+
     # Micro-to-USD conversions
     if "cost_micros" in item:
         try:
@@ -133,7 +127,7 @@ def _build_metrics(item: Dict[str, Any]) -> Dict[str, Decimal]:
             metrics["cost_usd"] = cost_micros / Decimal("1000000")
         except (ValueError, TypeError):
             pass  # Skip invalid cost values
-    
+
     # Handle CPA - only include if not null/N/A
     cpa_micros = item.get("cpa_micros")
     if cpa_micros is not None and str(cpa_micros).upper() != "N/A":
@@ -142,82 +136,84 @@ def _build_metrics(item: Dict[str, Any]) -> Dict[str, Decimal]:
             metrics["cpa_usd"] = cpa_value / Decimal("1000000")
         except (ValueError, TypeError):
             pass  # Skip invalid CPA values
-    
+
     return metrics
 
 
 def _build_dimensions(item: Dict[str, Any]) -> Dict[str, Any]:
     """Build dimensions dictionary."""
     dims = {}
-    
+
     # Direct fields
     if "video_duration_seconds" in item:
         dims["video_duration_seconds"] = item["video_duration_seconds"]
     if "performance_score" in item:
         dims["performance_score"] = item["performance_score"]
-    
+
     # Campaign and ad group (only if they exist and are non-empty)
     campaign_value = item.get("campaign")
     ad_group_value = item.get("ad_group")
-    
+
     campaign_name = str(campaign_value) if campaign_value is not None else ""
     ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
-    
+
     if campaign_name and campaign_name.strip():
         dims["campaign"] = campaign_name
     if ad_group_name and ad_group_name.strip():
         dims["ad_group"] = ad_group_name
-    
+
     return dims
 
 
-def _generate_finding_id(finding_type: str, counter: int, customer_id: str, date_range: DateRange) -> str:
+def _generate_finding_id(
+    finding_type: str, counter: int, customer_id: str, date_range: DateRange
+) -> str:
     """Generate collision-resistant finding ID with date range hash."""
     # Create a hash from date range to prevent collisions across different time periods
     date_hash_input = f"{date_range.start_date.isoformat()}_{date_range.end_date.isoformat()}"
     date_hash = hashlib.md5(date_hash_input.encode()).hexdigest()[:8]
-    
+
     sanitized_account = _sanitize_account_id(customer_id)
     return f"{finding_type}_{counter}_{sanitized_account}_{date_hash}"
 
 
 def _build_creative_finding(
-    item: Dict[str, Any], 
-    finding_type: str, 
-    counter: int, 
+    item: Dict[str, Any],
+    finding_type: str,
+    counter: int,
     customer_id: str,
     date_range: DateRange,
     severity: Severity,
-    default_recommendation: str
+    default_recommendation: str,
 ) -> Finding:
     """Build a Finding object for video creative data (poor or top performer)."""
     # Validate input data
     validated_item = _validate_numeric_ranges(item)
-    
+
     # Extract creative info
     creative_id, creative_name = _extract_creative_info(validated_item)
-    
+
     # Build components
     entities = _build_entities(creative_id, creative_name, validated_item)
     metrics = _build_metrics(validated_item)
     dims = _build_dimensions(validated_item)
-    
+
     # Generate finding details
     finding_id = _generate_finding_id(finding_type, counter, customer_id, date_range)
-    
+
     if finding_type.startswith("poor"):
         summary = f"Poor video creative: {creative_name}"
         used_severity = severity
     else:  # top performer
         summary = f"Top video creative: {creative_name}"
         used_severity = Severity.low  # Top performers always have low severity
-    
+
     recommendation = validated_item.get("recommendation", default_recommendation)
     description = str(recommendation) if recommendation is not None else default_recommendation
-    
+
     # Get creative entity for evidence
     creative_entity = next(e for e in entities if e.type == EntityType.other)
-    
+
     return Finding(
         id=finding_id,
         category="creative",
@@ -227,18 +223,13 @@ def _build_creative_finding(
         entities=entities,
         metrics=metrics,
         dims=dims,
-        evidence=[
-            Evidence(
-                source="paid_search_nav.video_creative",
-                entities=[creative_entity]
-            )
-        ]
+        evidence=[Evidence(source="paid_search_nav.video_creative", entities=[creative_entity])],
     )
 
 
 def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
     """Parser mapping PaidSearchNav VideoCreative analyzer output to AuditFindings.
-    
+
     Maps video creative performance data including poor and top performers with
     proper micro-to-USD conversions and video-specific metrics.
 
@@ -257,7 +248,7 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
 
     # Process poor performers and top performers using shared logic
     counter = 1
-    
+
     # Poor performers → findings
     for item in inp.detailed_findings.get("poor_performers", []) or []:
         finding = _build_creative_finding(
@@ -267,7 +258,7 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
             customer_id=inp.customer_id,
             date_range=date_range,
             severity=severity,
-            default_recommendation="Review video creative performance"
+            default_recommendation="Review video creative performance",
         )
         findings.append(finding)
         counter += 1
@@ -281,7 +272,7 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
             customer_id=inp.customer_id,
             date_range=date_range,
             severity=severity,  # Will be overridden to low in the helper function
-            default_recommendation="Continue high performance"
+            default_recommendation="Continue high performance",
         )
         findings.append(finding)
         counter += 1
@@ -296,7 +287,7 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
     aggregates = Aggregates()
     video_metrics = {}
     summary_data = inp.summary
-    
+
     if "total_video_creatives" in summary_data:
         video_metrics["total_video_creatives"] = Decimal(str(summary_data["total_video_creatives"]))
     if "poor_performers_count" in summary_data:
@@ -307,10 +298,7 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
         video_metrics["average_view_rate"] = Decimal(str(summary_data["average_view_rate"]))
 
     # Create global evidence and provenance
-    evidence = Evidence(
-        source="paid_search_nav.video_creative",
-        rows=len(findings)
-    )
+    evidence = Evidence(source="paid_search_nav.video_creative", rows=len(findings))
     prov = AnalyzerProvenance(
         name=inp.analyzer,
         version="unknown",
@@ -330,13 +318,13 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
     # Add video metrics to index for easy access
     if video_metrics:
         af.index["video_metrics"] = video_metrics
-    
+
     return af
 
 
 def _map_priority(level: Any) -> Severity:
     """Map priority level to Severity enum.
-    
+
     CRITICAL→high, HIGH→high, MEDIUM→medium, LOW→low
     """
     s = str(level or "").lower()

--- a/nav_insights/integrations/paid_search/video_creative.py
+++ b/nav_insights/integrations/paid_search/video_creative.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict, List
+
+from pydantic import BaseModel
+
+from ...core.findings_ir import (
+    AuditFindings,
+    AccountMeta,
+    DateRange,
+    Totals,
+    Aggregates,
+    Evidence,
+    AnalyzerProvenance,
+    Finding,
+    Severity,
+    EntityRef,
+    EntityType,
+)
+
+
+class VideoCreativeInput(BaseModel):
+    analyzer: str
+    customer_id: str
+    analysis_period: Dict[str, str]
+    timestamp: str
+    summary: Dict[str, Any]
+    detailed_findings: Dict[str, Any]
+
+
+def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
+    """Parser mapping PaidSearchNav VideoCreative analyzer output to AuditFindings.
+    
+    Maps video creative performance data including poor and top performers with
+    proper micro-to-USD conversions and video-specific metrics.
+
+    See docs/mappings/paid_search/video_creative_to_ir.md for full mapping details.
+    """
+    inp = VideoCreativeInput.model_validate(data)
+
+    start = datetime.fromisoformat(inp.analysis_period["start_date"]).date()
+    end = datetime.fromisoformat(inp.analysis_period["end_date"]).date()
+
+    account = AccountMeta(account_id=inp.customer_id)
+    date_range = DateRange(start_date=start, end_date=end)
+
+    findings: List[Finding] = []
+    severity = _map_priority(inp.summary.get("priority_level"))
+
+    # Poor performers → findings
+    counter = 1
+    for item in inp.detailed_findings.get("poor_performers", []) or []:
+        creative_id = str(item.get("creative_id", "unknown"))
+        creative_name = str(item.get("creative_name", "Unknown Creative"))
+        if not creative_name.strip():
+            creative_name = "Unknown Creative"
+        
+        # Create entities
+        creative_entity = EntityRef(
+            type=EntityType.other,
+            id=f"creative:{creative_id}",
+            name=creative_name
+        )
+        
+        campaign_value = item.get("campaign")
+        ad_group_value = item.get("ad_group")
+        
+        campaign_name = str(campaign_value) if campaign_value is not None else ""
+        ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
+        
+        entities = [creative_entity]
+        
+        if campaign_name and campaign_name.strip():
+            entities.append(EntityRef(
+                type=EntityType.campaign,
+                id=f"cmp:{campaign_name}",
+                name=campaign_name
+            ))
+            
+        if ad_group_name and ad_group_name.strip():
+            entities.append(EntityRef(
+                type=EntityType.ad_group,
+                id=f"adg:{ad_group_name}",
+                name=ad_group_name
+            ))
+
+        # Build metrics with micro-to-USD conversions
+        metrics = {}
+        if "impressions" in item:
+            metrics["impressions"] = Decimal(str(item["impressions"]))
+        if "views" in item:
+            metrics["views"] = Decimal(str(item["views"]))
+        if "view_rate" in item:
+            metrics["view_rate"] = Decimal(str(item["view_rate"]))
+        if "cost_micros" in item:
+            metrics["cost_usd"] = Decimal(str(item["cost_micros"])) / Decimal("1000000")
+        if "conversions" in item:
+            metrics["conversions"] = Decimal(str(item["conversions"]))
+        if "performance_score" in item:
+            metrics["performance_score"] = Decimal(str(item["performance_score"]))
+        
+        # Handle CPA - only include if not null/N/A
+        cpa_micros = item.get("cpa_micros")
+        if cpa_micros is not None and str(cpa_micros).upper() != "N/A":
+            try:
+                metrics["cpa_usd"] = Decimal(str(cpa_micros)) / Decimal("1000000")
+            except (ValueError, TypeError):
+                pass  # Skip invalid CPA values
+
+        # Build dimensions
+        dims = {}
+        if "video_duration_seconds" in item:
+            dims["video_duration_seconds"] = item["video_duration_seconds"]
+        if campaign_name and campaign_name.strip():
+            dims["campaign"] = campaign_name
+        if ad_group_name and ad_group_name.strip():
+            dims["ad_group"] = ad_group_name
+        if "performance_score" in item:
+            dims["performance_score"] = item["performance_score"]
+
+        finding_id = f"poor_video_{counter}_{_sanitize_account_id(inp.customer_id)}"
+        summary = f"Poor video creative: {creative_name}"
+        recommendation = item.get("recommendation", "Review video creative performance")
+        description = str(recommendation) if recommendation is not None else "Review video creative performance"
+
+        findings.append(
+            Finding(
+                id=finding_id,
+                category="creative",
+                summary=summary,
+                description=description,
+                severity=severity,
+                entities=entities,
+                metrics=metrics,
+                dims=dims,
+                evidence=[
+                    Evidence(
+                        source="paid_search_nav.video_creative",
+                        entities=[creative_entity]
+                    )
+                ]
+            )
+        )
+        counter += 1
+
+    # Top performers → findings (with low severity for positive findings)
+    for item in inp.detailed_findings.get("top_performers", []) or []:
+        creative_id = str(item.get("creative_id", "unknown"))
+        creative_name = str(item.get("creative_name", "Unknown Creative"))
+        if not creative_name.strip():
+            creative_name = "Unknown Creative"
+        
+        # Create entities
+        creative_entity = EntityRef(
+            type=EntityType.other,
+            id=f"creative:{creative_id}",
+            name=creative_name
+        )
+        
+        campaign_value = item.get("campaign")
+        ad_group_value = item.get("ad_group")
+        
+        campaign_name = str(campaign_value) if campaign_value is not None else ""
+        ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
+        
+        entities = [creative_entity]
+        
+        if campaign_name and campaign_name.strip():
+            entities.append(EntityRef(
+                type=EntityType.campaign,
+                id=f"cmp:{campaign_name}",
+                name=campaign_name
+            ))
+            
+        if ad_group_name and ad_group_name.strip():
+            entities.append(EntityRef(
+                type=EntityType.ad_group,
+                id=f"adg:{ad_group_name}",
+                name=ad_group_name
+            ))
+
+        # Build metrics with micro-to-USD conversions
+        metrics = {}
+        if "impressions" in item:
+            metrics["impressions"] = Decimal(str(item["impressions"]))
+        if "views" in item:
+            metrics["views"] = Decimal(str(item["views"]))
+        if "view_rate" in item:
+            metrics["view_rate"] = Decimal(str(item["view_rate"]))
+        if "cost_micros" in item:
+            metrics["cost_usd"] = Decimal(str(item["cost_micros"])) / Decimal("1000000")
+        if "conversions" in item:
+            metrics["conversions"] = Decimal(str(item["conversions"]))
+        if "performance_score" in item:
+            metrics["performance_score"] = Decimal(str(item["performance_score"]))
+        
+        # Handle CPA - only include if not null/N/A
+        cpa_micros = item.get("cpa_micros")
+        if cpa_micros is not None and str(cpa_micros).upper() != "N/A":
+            try:
+                metrics["cpa_usd"] = Decimal(str(cpa_micros)) / Decimal("1000000")
+            except (ValueError, TypeError):
+                pass  # Skip invalid CPA values
+
+        # Build dimensions
+        dims = {}
+        if "video_duration_seconds" in item:
+            dims["video_duration_seconds"] = item["video_duration_seconds"]
+        if campaign_name and campaign_name.strip():
+            dims["campaign"] = campaign_name
+        if ad_group_name and ad_group_name.strip():
+            dims["ad_group"] = ad_group_name
+        if "performance_score" in item:
+            dims["performance_score"] = item["performance_score"]
+
+        finding_id = f"top_video_{counter}_{_sanitize_account_id(inp.customer_id)}"
+        summary = f"Top video creative: {creative_name}"
+        recommendation = item.get("recommendation", "Continue high performance")
+        description = str(recommendation) if recommendation is not None else "Continue high performance"
+
+        findings.append(
+            Finding(
+                id=finding_id,
+                category="creative",
+                summary=summary,
+                description=description,
+                severity=Severity.low,  # Top performers have low severity (positive finding)
+                entities=entities,
+                metrics=metrics,
+                dims=dims,
+                evidence=[
+                    Evidence(
+                        source="paid_search_nav.video_creative",
+                        entities=[creative_entity]
+                    )
+                ]
+            )
+        )
+        counter += 1
+
+    # Build totals with spend conversion
+    totals = Totals()
+    if "total_video_spend_micros" in inp.summary:
+        spend_micros = inp.summary["total_video_spend_micros"]
+        totals.spend_usd = Decimal(str(spend_micros)) / Decimal("1000000")
+
+    # Build aggregates with video-specific metrics
+    aggregates = Aggregates()
+    video_metrics = {}
+    summary_data = inp.summary
+    
+    if "total_video_creatives" in summary_data:
+        video_metrics["total_video_creatives"] = Decimal(str(summary_data["total_video_creatives"]))
+    if "poor_performers_count" in summary_data:
+        video_metrics["poor_performers_count"] = Decimal(str(summary_data["poor_performers_count"]))
+    if "top_performers_count" in summary_data:
+        video_metrics["top_performers_count"] = Decimal(str(summary_data["top_performers_count"]))
+    if "average_view_rate" in summary_data:
+        video_metrics["average_view_rate"] = Decimal(str(summary_data["average_view_rate"]))
+
+    # Create global evidence and provenance
+    evidence = Evidence(
+        source="paid_search_nav.video_creative",
+        rows=len(findings)
+    )
+    prov = AnalyzerProvenance(
+        name=inp.analyzer,
+        version="unknown",
+        finished_at=datetime.fromisoformat(inp.timestamp),
+    )
+
+    af = AuditFindings(
+        account=account,
+        date_range=date_range,
+        totals=totals,
+        aggregates=aggregates,
+        findings=findings,
+        data_sources=[evidence],
+        analyzers=[prov],
+    )
+
+    # Add video metrics to index for easy access
+    if video_metrics:
+        af.index["video_metrics"] = video_metrics
+    
+    return af
+
+
+def _map_priority(level: Any) -> Severity:
+    """Map priority level to Severity enum.
+    
+    CRITICAL→high, HIGH→high, MEDIUM→medium, LOW→low
+    """
+    s = str(level or "").lower()
+    if s in ("critical", "high"):
+        return Severity.high
+    if s == "medium":
+        return Severity.medium
+    return Severity.low
+
+
+def _sanitize_account_id(account_id: str) -> str:
+    """Sanitize account ID for use in finding IDs."""
+    return account_id.replace("-", "_").replace(" ", "_")

--- a/nav_insights/integrations/paid_search/video_creative.py
+++ b/nav_insights/integrations/paid_search/video_creative.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
+import hashlib
 
 from pydantic import BaseModel
 
@@ -29,6 +30,212 @@ class VideoCreativeInput(BaseModel):
     detailed_findings: Dict[str, Any]
 
 
+def _validate_numeric_ranges(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and clamp numeric values to expected ranges."""
+    validated_item = item.copy()
+    
+    # Validate view_rate is in [0,1] range
+    if "view_rate" in validated_item:
+        try:
+            view_rate = float(validated_item["view_rate"])
+            if view_rate < 0 or view_rate > 1:
+                # Log warning in production, for now just clamp
+                validated_item["view_rate"] = max(0, min(1, view_rate))
+        except (ValueError, TypeError):
+            validated_item["view_rate"] = 0
+    
+    # Validate performance_score is in [0,1] range  
+    if "performance_score" in validated_item:
+        try:
+            perf_score = float(validated_item["performance_score"])
+            if perf_score < 0 or perf_score > 1:
+                validated_item["performance_score"] = max(0, min(1, perf_score))
+        except (ValueError, TypeError):
+            validated_item["performance_score"] = 0
+    
+    return validated_item
+
+
+def _extract_creative_info(item: Dict[str, Any]) -> Tuple[str, str]:
+    """Extract and validate creative ID and name from item."""
+    creative_id = str(item.get("creative_id", "unknown"))
+    creative_name = str(item.get("creative_name", "Unknown Creative"))
+    
+    if not creative_name.strip():
+        creative_name = "Unknown Creative"
+    
+    return creative_id, creative_name
+
+
+def _build_entities(creative_id: str, creative_name: str, item: Dict[str, Any]) -> List[EntityRef]:
+    """Build EntityRef objects for creative, campaign, and ad group."""
+    # Create creative entity
+    creative_entity = EntityRef(
+        type=EntityType.other,
+        id=f"creative:{creative_id}",
+        name=creative_name
+    )
+    
+    entities = [creative_entity]
+    
+    # Handle campaign and ad group entities
+    campaign_value = item.get("campaign")
+    ad_group_value = item.get("ad_group")
+    
+    campaign_name = str(campaign_value) if campaign_value is not None else ""
+    ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
+    
+    if campaign_name and campaign_name.strip():
+        entities.append(EntityRef(
+            type=EntityType.campaign,
+            id=f"cmp:{campaign_name}",
+            name=campaign_name
+        ))
+        
+    if ad_group_name and ad_group_name.strip():
+        entities.append(EntityRef(
+            type=EntityType.ad_group,
+            id=f"adg:{ad_group_name}",
+            name=ad_group_name
+        ))
+    
+    return entities
+
+
+def _build_metrics(item: Dict[str, Any]) -> Dict[str, Decimal]:
+    """Build metrics dictionary with micro-to-USD conversions and validation."""
+    metrics = {}
+    
+    # Standard metrics
+    metric_fields = ["impressions", "views", "conversions", "performance_score"]
+    for field in metric_fields:
+        if field in item:
+            try:
+                metrics[field] = Decimal(str(item[field]))
+            except (ValueError, TypeError):
+                metrics[field] = Decimal("0")
+    
+    # View rate with validation
+    if "view_rate" in item:
+        try:
+            view_rate = Decimal(str(item["view_rate"]))
+            # Ensure it's in [0,1] range
+            if view_rate < 0 or view_rate > 1:
+                view_rate = max(Decimal("0"), min(Decimal("1"), view_rate))
+            metrics["view_rate"] = view_rate
+        except (ValueError, TypeError):
+            metrics["view_rate"] = Decimal("0")
+    
+    # Micro-to-USD conversions
+    if "cost_micros" in item:
+        try:
+            cost_micros = Decimal(str(item["cost_micros"]))
+            metrics["cost_usd"] = cost_micros / Decimal("1000000")
+        except (ValueError, TypeError):
+            pass  # Skip invalid cost values
+    
+    # Handle CPA - only include if not null/N/A
+    cpa_micros = item.get("cpa_micros")
+    if cpa_micros is not None and str(cpa_micros).upper() != "N/A":
+        try:
+            cpa_value = Decimal(str(cpa_micros))
+            metrics["cpa_usd"] = cpa_value / Decimal("1000000")
+        except (ValueError, TypeError):
+            pass  # Skip invalid CPA values
+    
+    return metrics
+
+
+def _build_dimensions(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Build dimensions dictionary."""
+    dims = {}
+    
+    # Direct fields
+    if "video_duration_seconds" in item:
+        dims["video_duration_seconds"] = item["video_duration_seconds"]
+    if "performance_score" in item:
+        dims["performance_score"] = item["performance_score"]
+    
+    # Campaign and ad group (only if they exist and are non-empty)
+    campaign_value = item.get("campaign")
+    ad_group_value = item.get("ad_group")
+    
+    campaign_name = str(campaign_value) if campaign_value is not None else ""
+    ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
+    
+    if campaign_name and campaign_name.strip():
+        dims["campaign"] = campaign_name
+    if ad_group_name and ad_group_name.strip():
+        dims["ad_group"] = ad_group_name
+    
+    return dims
+
+
+def _generate_finding_id(finding_type: str, counter: int, customer_id: str, date_range: DateRange) -> str:
+    """Generate collision-resistant finding ID with date range hash."""
+    # Create a hash from date range to prevent collisions across different time periods
+    date_hash_input = f"{date_range.start_date.isoformat()}_{date_range.end_date.isoformat()}"
+    date_hash = hashlib.md5(date_hash_input.encode()).hexdigest()[:8]
+    
+    sanitized_account = _sanitize_account_id(customer_id)
+    return f"{finding_type}_{counter}_{sanitized_account}_{date_hash}"
+
+
+def _build_creative_finding(
+    item: Dict[str, Any], 
+    finding_type: str, 
+    counter: int, 
+    customer_id: str,
+    date_range: DateRange,
+    severity: Severity,
+    default_recommendation: str
+) -> Finding:
+    """Build a Finding object for video creative data (poor or top performer)."""
+    # Validate input data
+    validated_item = _validate_numeric_ranges(item)
+    
+    # Extract creative info
+    creative_id, creative_name = _extract_creative_info(validated_item)
+    
+    # Build components
+    entities = _build_entities(creative_id, creative_name, validated_item)
+    metrics = _build_metrics(validated_item)
+    dims = _build_dimensions(validated_item)
+    
+    # Generate finding details
+    finding_id = _generate_finding_id(finding_type, counter, customer_id, date_range)
+    
+    if finding_type.startswith("poor"):
+        summary = f"Poor video creative: {creative_name}"
+        used_severity = severity
+    else:  # top performer
+        summary = f"Top video creative: {creative_name}"
+        used_severity = Severity.low  # Top performers always have low severity
+    
+    recommendation = validated_item.get("recommendation", default_recommendation)
+    description = str(recommendation) if recommendation is not None else default_recommendation
+    
+    # Get creative entity for evidence
+    creative_entity = next(e for e in entities if e.type == EntityType.other)
+    
+    return Finding(
+        id=finding_id,
+        category="creative",
+        summary=summary,
+        description=description,
+        severity=used_severity,
+        entities=entities,
+        metrics=metrics,
+        dims=dims,
+        evidence=[
+            Evidence(
+                source="paid_search_nav.video_creative",
+                entities=[creative_entity]
+            )
+        ]
+    )
+
+
 def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
     """Parser mapping PaidSearchNav VideoCreative analyzer output to AuditFindings.
     
@@ -48,195 +255,35 @@ def parse_video_creative(data: Dict[str, Any]) -> AuditFindings:
     findings: List[Finding] = []
     severity = _map_priority(inp.summary.get("priority_level"))
 
-    # Poor performers → findings
+    # Process poor performers and top performers using shared logic
     counter = 1
+    
+    # Poor performers → findings
     for item in inp.detailed_findings.get("poor_performers", []) or []:
-        creative_id = str(item.get("creative_id", "unknown"))
-        creative_name = str(item.get("creative_name", "Unknown Creative"))
-        if not creative_name.strip():
-            creative_name = "Unknown Creative"
-        
-        # Create entities
-        creative_entity = EntityRef(
-            type=EntityType.other,
-            id=f"creative:{creative_id}",
-            name=creative_name
+        finding = _build_creative_finding(
+            item=item,
+            finding_type="poor_video",
+            counter=counter,
+            customer_id=inp.customer_id,
+            date_range=date_range,
+            severity=severity,
+            default_recommendation="Review video creative performance"
         )
-        
-        campaign_value = item.get("campaign")
-        ad_group_value = item.get("ad_group")
-        
-        campaign_name = str(campaign_value) if campaign_value is not None else ""
-        ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
-        
-        entities = [creative_entity]
-        
-        if campaign_name and campaign_name.strip():
-            entities.append(EntityRef(
-                type=EntityType.campaign,
-                id=f"cmp:{campaign_name}",
-                name=campaign_name
-            ))
-            
-        if ad_group_name and ad_group_name.strip():
-            entities.append(EntityRef(
-                type=EntityType.ad_group,
-                id=f"adg:{ad_group_name}",
-                name=ad_group_name
-            ))
-
-        # Build metrics with micro-to-USD conversions
-        metrics = {}
-        if "impressions" in item:
-            metrics["impressions"] = Decimal(str(item["impressions"]))
-        if "views" in item:
-            metrics["views"] = Decimal(str(item["views"]))
-        if "view_rate" in item:
-            metrics["view_rate"] = Decimal(str(item["view_rate"]))
-        if "cost_micros" in item:
-            metrics["cost_usd"] = Decimal(str(item["cost_micros"])) / Decimal("1000000")
-        if "conversions" in item:
-            metrics["conversions"] = Decimal(str(item["conversions"]))
-        if "performance_score" in item:
-            metrics["performance_score"] = Decimal(str(item["performance_score"]))
-        
-        # Handle CPA - only include if not null/N/A
-        cpa_micros = item.get("cpa_micros")
-        if cpa_micros is not None and str(cpa_micros).upper() != "N/A":
-            try:
-                metrics["cpa_usd"] = Decimal(str(cpa_micros)) / Decimal("1000000")
-            except (ValueError, TypeError):
-                pass  # Skip invalid CPA values
-
-        # Build dimensions
-        dims = {}
-        if "video_duration_seconds" in item:
-            dims["video_duration_seconds"] = item["video_duration_seconds"]
-        if campaign_name and campaign_name.strip():
-            dims["campaign"] = campaign_name
-        if ad_group_name and ad_group_name.strip():
-            dims["ad_group"] = ad_group_name
-        if "performance_score" in item:
-            dims["performance_score"] = item["performance_score"]
-
-        finding_id = f"poor_video_{counter}_{_sanitize_account_id(inp.customer_id)}"
-        summary = f"Poor video creative: {creative_name}"
-        recommendation = item.get("recommendation", "Review video creative performance")
-        description = str(recommendation) if recommendation is not None else "Review video creative performance"
-
-        findings.append(
-            Finding(
-                id=finding_id,
-                category="creative",
-                summary=summary,
-                description=description,
-                severity=severity,
-                entities=entities,
-                metrics=metrics,
-                dims=dims,
-                evidence=[
-                    Evidence(
-                        source="paid_search_nav.video_creative",
-                        entities=[creative_entity]
-                    )
-                ]
-            )
-        )
+        findings.append(finding)
         counter += 1
 
     # Top performers → findings (with low severity for positive findings)
     for item in inp.detailed_findings.get("top_performers", []) or []:
-        creative_id = str(item.get("creative_id", "unknown"))
-        creative_name = str(item.get("creative_name", "Unknown Creative"))
-        if not creative_name.strip():
-            creative_name = "Unknown Creative"
-        
-        # Create entities
-        creative_entity = EntityRef(
-            type=EntityType.other,
-            id=f"creative:{creative_id}",
-            name=creative_name
+        finding = _build_creative_finding(
+            item=item,
+            finding_type="top_video",
+            counter=counter,
+            customer_id=inp.customer_id,
+            date_range=date_range,
+            severity=severity,  # Will be overridden to low in the helper function
+            default_recommendation="Continue high performance"
         )
-        
-        campaign_value = item.get("campaign")
-        ad_group_value = item.get("ad_group")
-        
-        campaign_name = str(campaign_value) if campaign_value is not None else ""
-        ad_group_name = str(ad_group_value) if ad_group_value is not None else ""
-        
-        entities = [creative_entity]
-        
-        if campaign_name and campaign_name.strip():
-            entities.append(EntityRef(
-                type=EntityType.campaign,
-                id=f"cmp:{campaign_name}",
-                name=campaign_name
-            ))
-            
-        if ad_group_name and ad_group_name.strip():
-            entities.append(EntityRef(
-                type=EntityType.ad_group,
-                id=f"adg:{ad_group_name}",
-                name=ad_group_name
-            ))
-
-        # Build metrics with micro-to-USD conversions
-        metrics = {}
-        if "impressions" in item:
-            metrics["impressions"] = Decimal(str(item["impressions"]))
-        if "views" in item:
-            metrics["views"] = Decimal(str(item["views"]))
-        if "view_rate" in item:
-            metrics["view_rate"] = Decimal(str(item["view_rate"]))
-        if "cost_micros" in item:
-            metrics["cost_usd"] = Decimal(str(item["cost_micros"])) / Decimal("1000000")
-        if "conversions" in item:
-            metrics["conversions"] = Decimal(str(item["conversions"]))
-        if "performance_score" in item:
-            metrics["performance_score"] = Decimal(str(item["performance_score"]))
-        
-        # Handle CPA - only include if not null/N/A
-        cpa_micros = item.get("cpa_micros")
-        if cpa_micros is not None and str(cpa_micros).upper() != "N/A":
-            try:
-                metrics["cpa_usd"] = Decimal(str(cpa_micros)) / Decimal("1000000")
-            except (ValueError, TypeError):
-                pass  # Skip invalid CPA values
-
-        # Build dimensions
-        dims = {}
-        if "video_duration_seconds" in item:
-            dims["video_duration_seconds"] = item["video_duration_seconds"]
-        if campaign_name and campaign_name.strip():
-            dims["campaign"] = campaign_name
-        if ad_group_name and ad_group_name.strip():
-            dims["ad_group"] = ad_group_name
-        if "performance_score" in item:
-            dims["performance_score"] = item["performance_score"]
-
-        finding_id = f"top_video_{counter}_{_sanitize_account_id(inp.customer_id)}"
-        summary = f"Top video creative: {creative_name}"
-        recommendation = item.get("recommendation", "Continue high performance")
-        description = str(recommendation) if recommendation is not None else "Continue high performance"
-
-        findings.append(
-            Finding(
-                id=finding_id,
-                category="creative",
-                summary=summary,
-                description=description,
-                severity=Severity.low,  # Top performers have low severity (positive finding)
-                entities=entities,
-                metrics=metrics,
-                dims=dims,
-                evidence=[
-                    Evidence(
-                        source="paid_search_nav.video_creative",
-                        entities=[creative_entity]
-                    )
-                ]
-            )
-        )
+        findings.append(finding)
         counter += 1
 
     # Build totals with spend conversion

--- a/tests/fixtures/video_creative_edge_case.json
+++ b/tests/fixtures/video_creative_edge_case.json
@@ -1,0 +1,76 @@
+{
+  "analyzer": "VideoCreative",
+  "customer_id": "edge-case-123",
+  "analysis_period": {
+    "start_date": "2025-08-15T00:00:00",
+    "end_date": "2025-08-22T00:00:00"
+  },
+  "timestamp": "2025-08-22T10:00:00",
+  "summary": {
+    "total_video_creatives": 8,
+    "poor_performers_count": 2,
+    "top_performers_count": 1,
+    "total_video_spend_micros": 1200000000,
+    "average_view_rate": 0.05,
+    "priority_level": "LOW"
+  },
+  "detailed_findings": {
+    "poor_performers": [
+      {
+        "creative_id": "",
+        "creative_name": "",
+        "video_duration_seconds": 0,
+        "impressions": 1000,
+        "views": 50,
+        "view_rate": 0.05,
+        "cost_micros": 50000000,
+        "conversions": 0,
+        "cpa_micros": null,
+        "campaign": null,
+        "ad_group": "",
+        "recommendation": null,
+        "performance_score": 0.01
+      },
+      {
+        "creative_id": "edge_123",
+        "creative_name": "Creative with Special Chars!@#$%",
+        "video_duration_seconds": 90,
+        "impressions": 500,
+        "views": 15,
+        "view_rate": 0.03,
+        "cost_micros": 25000000,
+        "conversions": 0,
+        "cpa_micros": "N/A",
+        "campaign": "Campaign with-dashes_and underscores",
+        "ad_group": "Ad Group (Parentheses) & Symbols",
+        "recommendation": "Creative performs poorly across all metrics",
+        "performance_score": 0.02
+      }
+    ],
+    "top_performers": [
+      {
+        "creative_id": "top_edge_456",
+        "creative_name": "Edge Case Winner",
+        "video_duration_seconds": 25,
+        "impressions": 2000,
+        "views": 400,
+        "view_rate": 0.20,
+        "cost_micros": 75000000,
+        "conversions": 5,
+        "cpa_micros": 15000000,
+        "campaign": "",
+        "ad_group": null,
+        "recommendation": "Good performance despite limited data",
+        "performance_score": 0.65
+      }
+    ],
+    "insights": [
+      "Limited data available for this period",
+      "Overall video performance needs improvement"
+    ],
+    "recommendations": [
+      "Gather more data before making optimization decisions",
+      "Focus on proven creative formats"
+    ]
+  }
+}

--- a/tests/fixtures/video_creative_happy_path.json
+++ b/tests/fixtures/video_creative_happy_path.json
@@ -1,0 +1,108 @@
+{
+  "analyzer": "VideoCreative",
+  "customer_id": "123-456-7890",
+  "analysis_period": {
+    "start_date": "2025-08-01T00:00:00",
+    "end_date": "2025-08-24T00:00:00"
+  },
+  "timestamp": "2025-08-24T15:30:00",
+  "summary": {
+    "total_video_creatives": 25,
+    "poor_performers_count": 3,
+    "top_performers_count": 5,
+    "total_video_spend_micros": 5420000000,
+    "average_view_rate": 0.18,
+    "priority_level": "HIGH"
+  },
+  "detailed_findings": {
+    "poor_performers": [
+      {
+        "creative_id": "12345",
+        "creative_name": "Summer Sale 30s",
+        "video_duration_seconds": 30,
+        "impressions": 45000,
+        "views": 5400,
+        "view_rate": 0.12,
+        "cost_micros": 892450000,
+        "conversions": 0,
+        "cpa_micros": "N/A",
+        "campaign": "Video Campaign",
+        "ad_group": "Summer Promotions",
+        "recommendation": "Low view rate (12%) - consider shorter duration or more engaging opening",
+        "performance_score": 0.12
+      },
+      {
+        "creative_id": "12346",
+        "creative_name": "Product Demo 45s",
+        "video_duration_seconds": 45,
+        "impressions": 38000,
+        "views": 4560,
+        "view_rate": 0.12,
+        "cost_micros": 1245780000,
+        "conversions": 2,
+        "cpa_micros": 622890000,
+        "campaign": "Product Videos",
+        "ad_group": "Demo Content",
+        "recommendation": "High cost per view - optimize targeting or shorten video",
+        "performance_score": 0.15
+      },
+      {
+        "creative_id": "12347",
+        "creative_name": "Brand Story 60s",
+        "video_duration_seconds": 60,
+        "impressions": 28000,
+        "views": 2240,
+        "view_rate": 0.08,
+        "cost_micros": 756340000,
+        "conversions": 1,
+        "cpa_micros": 756340000,
+        "campaign": "Brand Awareness",
+        "ad_group": "Story Content",
+        "recommendation": "Very low view rate (8%) - needs complete creative refresh",
+        "performance_score": 0.08
+      }
+    ],
+    "top_performers": [
+      {
+        "creative_id": "12348",
+        "creative_name": "Quick Tips 15s",
+        "video_duration_seconds": 15,
+        "impressions": 52000,
+        "views": 20800,
+        "view_rate": 0.40,
+        "cost_micros": 345670000,
+        "conversions": 28,
+        "cpa_micros": 12345000,
+        "campaign": "Tips & Tricks",
+        "ad_group": "Quick Content",
+        "recommendation": "Excellent performance - consider increasing budget",
+        "performance_score": 0.89
+      },
+      {
+        "creative_id": "12349",
+        "creative_name": "Customer Testimonial 20s",
+        "video_duration_seconds": 20,
+        "impressions": 41000,
+        "views": 14350,
+        "view_rate": 0.35,
+        "cost_micros": 289450000,
+        "conversions": 22,
+        "cpa_micros": 13156818,
+        "campaign": "Social Proof",
+        "ad_group": "Testimonials",
+        "recommendation": "Strong social proof element drives conversions",
+        "performance_score": 0.82
+      }
+    ],
+    "insights": [
+      "Shorter videos (15-20s) perform significantly better than longer formats",
+      "Social proof and testimonials drive higher engagement",
+      "Videos over 45 seconds show declining view rates"
+    ],
+    "recommendations": [
+      "Focus budget on 15-20 second video formats",
+      "Test more customer testimonial content",
+      "Refresh creative assets with poor performance scores"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Implements a comprehensive video creative performance analyzer mapping that transforms PaidSearchNav VideoCreative analyzer outputs to Core IR AuditFindings.

• **Parser Implementation**: Maps poor_performers and top_performers to Finding objects with proper severity levels  
• **Currency Conversions**: Handles micro-to-USD conversions for cost_micros, cpa_micros, and total_video_spend_micros  
• **Entity Handling**: Creates EntityRef objects for creatives (as "other" type), campaigns, and ad groups  
• **Null Value Safety**: Robust handling of null/empty campaign, ad_group, and recommendation fields  
• **Video Metrics**: Captures video-specific metrics like view_rate, video_duration_seconds, performance_score  
• **Comprehensive Testing**: 7 test functions covering smoke tests, comprehensive mapping, fixtures, conversions, and edge cases  

## Test plan
- [x] All 7 video_creative tests pass (including edge case fixture)
- [x] All existing paid search parser tests continue to pass (26/26)
- [x] Ruff linting passes with no issues
- [x] Mapping specification documented in `docs/mappings/paid_search/video_creative_to_ir.md`
- [x] Parser exported in `__init__.py` for integration use

🤖 Generated with [Claude Code](https://claude.ai/code)